### PR TITLE
Add parameter to Fragment Properties for shaped charges.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -37,7 +37,7 @@ namespace CombatExtended
             var fragPerTick = Mathf.CeilToInt((float)fragToSpawn / TicksToSpawnAllFrag);
             var fragSpawnedInTick = 0;
 
-            while (fragToSpawn-- > 0 && Find.Maps.IndexOf(map) >= 0)
+            while (fragToSpawn-- > 0)
             {
                 var projectile = (ProjectileCE)ThingMaker.MakeThing(frag.thingDef);
                 GenSpawn.Spawn(projectile, cell, map);
@@ -61,6 +61,10 @@ namespace CombatExtended
                 {
                     fragSpawnedInTick = 0;
                     yield return new WaitForEndOfFrame();
+                    if (Find.Maps.IndexOf(map) < 0)
+                    {
+                        break;
+                    }
                 }
             }
         }

--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -28,7 +28,7 @@ namespace CombatExtended
 
         public CompProperties_Fragments PropsCE => (CompProperties_Fragments)props;
 
-        private static IEnumerator FragRoutine(Vector3 pos, Map map, float height, Thing instigator, ThingDefCountClass frag, float fragSpeedFactor, float fragShadowChance, FloatRange fragAngleRange)
+        private static IEnumerator FragRoutine(Vector3 pos, Map map, float height, Thing instigator, ThingDefCountClass frag, float fragSpeedFactor, float fragShadowChance, FloatRange fragAngleRange, FloatRange fragXZAngleRange)
         {
             var cell = pos.ToIntVec3();
             var exactOrigin = new Vector2(pos.x, pos.z);
@@ -37,7 +37,7 @@ namespace CombatExtended
             var fragPerTick = Mathf.CeilToInt((float)fragToSpawn / TicksToSpawnAllFrag);
             var fragSpawnedInTick = 0;
 
-            while (fragToSpawn > 0 && Find.Maps.IndexOf(map) >= 0)
+            while (fragToSpawn-- > 0 && Find.Maps.IndexOf(map) >= 0)
             {
                 var projectile = (ProjectileCE)ThingMaker.MakeThing(frag.thingDef);
                 GenSpawn.Spawn(projectile, cell, map);
@@ -50,13 +50,12 @@ namespace CombatExtended
                     instigator,
                     exactOrigin,
                     fragAngleRange.RandomInRange * Mathf.Deg2Rad,
-                    Rand.Range(0, 360),
+		    (fragXZAngleRange.RandomInRange + 360) % 360,
                     height,
                     fragSpeedFactor * projectile.def.projectile.speed,
                     projectile
                 );
 
-                fragToSpawn--;
                 fragSpawnedInTick++;
                 if (fragSpawnedInTick >= fragPerTick)
                 {
@@ -84,13 +83,14 @@ namespace CombatExtended
                 var edifice = pos.ToIntVec3().GetEdifice(map);
                 var edificeHeight = edifice == null ? 0f : new CollisionVertical(edifice).Max;
                 var height = projCE != null ? Mathf.Max(edificeHeight, projCE.Height) : edificeHeight;
+		var fragXZAngleRange = new FloatRange(projCE.shotRotation + PropsCE.fragXZAngleRange.min, projCE.shotRotation + PropsCE.fragXZAngleRange.max);
 
                 foreach (var fragment in PropsCE.fragments)
                 {
                     var newCount = fragment;
                     newCount.count = Mathf.RoundToInt(newCount.count * scaleFactor);
 
-                    var routine = FragRoutine(pos, map, height, instigator, fragment, PropsCE.fragSpeedFactor, PropsCE.fragShadowChance, PropsCE.fragAngleRange);
+                    var routine = FragRoutine(pos, map, height, instigator, fragment, PropsCE.fragSpeedFactor, PropsCE.fragShadowChance, PropsCE.fragAngleRange, fragXZAngleRange);
                     if (!Compatibility.Multiplayer.InMultiplayer)
                         _monoDummy.GetComponent<MonoDummy>().StartCoroutine(routine);
                     else

--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -83,11 +83,24 @@ namespace CombatExtended
                     Log.Warning("CombatExtended :: Tried to throw fragments out of bounds");
                     return;
                 }
-                var projCE = parent as ProjectileCE;
-                var edifice = pos.ToIntVec3().GetEdifice(map);
-                var edificeHeight = edifice == null ? 0f : new CollisionVertical(edifice).Max;
-                var height = projCE != null ? Mathf.Max(edificeHeight, projCE.Height) : edificeHeight;
-		var fragXZAngleRange = new FloatRange(projCE.shotRotation + PropsCE.fragXZAngleRange.min, projCE.shotRotation + PropsCE.fragXZAngleRange.max);
+		float height;
+		FloatRange fragXZAngleRange;
+		if (parent is ProjectileCE projCE)
+		{
+		    height = projCE.Height;
+		    fragXZAngleRange = new FloatRange(projCE.shotRotation + PropsCE.fragXZAngleRange.min, projCE.shotRotation + PropsCE.fragXZAngleRange.max);
+		}
+		else
+		{
+		    height = 0;
+		    fragXZAngleRange = PropsCE.fragXZAngleRange;
+		}
+		var edifice = pos.ToIntVec3().GetEdifice(map);
+                if (edifice != null)
+		{
+		    var edificeHeight = new CollisionVertical(edifice).Max;
+		    height = Mathf.Max(height, edificeHeight);
+		}
 
                 foreach (var fragment in PropsCE.fragments)
                 {

--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -95,8 +95,7 @@ namespace CombatExtended
 		    height = 0;
 		    fragXZAngleRange = PropsCE.fragXZAngleRange;
 		}
-		var edifice = pos.ToIntVec3().GetEdifice(map);
-                if (edifice != null)
+                if (pos.ToIntVec3().GetEdifice(map) is Building edifice)
 		{
 		    var edificeHeight = new CollisionVertical(edifice).Max;
 		    height = Mathf.Max(height, edificeHeight);

--- a/Source/CombatExtended/CombatExtended/Comps/CompProperties_Fragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompProperties_Fragments.cs
@@ -14,6 +14,7 @@ namespace CombatExtended
         public float fragSpeedFactor = 1f;
         public float fragShadowChance = 0.2f;
         public FloatRange fragAngleRange = new FloatRange(0.5f, 5f);
+	public FloatRange fragXZAngleRange = new FloatRange(0f, 360f);
 
         public CompProperties_Fragments()
         {


### PR DESCRIPTION
I added the second range to the `CombatExtended.CompProperties_Fragments`, as that lets shaped charges include it easily in that entry of their XML per-ammo.  